### PR TITLE
feat: Add Support for a HTTP Callback.

### DIFF
--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -102,6 +102,7 @@ type PathConf struct {
 	RunOnPublishRestart     bool          `yaml:"runOnPublishRestart"`
 	RunOnRead               string        `yaml:"runOnRead"`
 	RunOnReadRestart        bool          `yaml:"runOnReadRestart"`
+	HTTPCallback            string        `yaml:"httpCallback"`
 }
 
 func (pconf *PathConf) GetInstance(name string) *PathConf {

--- a/internal/pathman/pathman.go
+++ b/internal/pathman/pathman.go
@@ -149,9 +149,9 @@ outer:
 
 			// remove paths associated with a conf which doesn't exist anymore
 			// or has changed
-			for name, pa := range pm.paths {
+			for source, pa := range pm.paths {
 				if pathConf, ok := pm.pathConfs[pa.ConfName()]; !ok || pathConf != pa.Conf() {
-					delete(pm.paths, name)
+					delete(pm.paths, source)
 					pa.Close()
 				}
 			}
@@ -163,7 +163,7 @@ outer:
 			if pmpa, ok := pm.paths[pa.Conf().Source]; !ok || pmpa != pa {
 				continue
 			}
-			delete(pm.paths, pa.Name())
+			delete(pm.paths, pa.Conf().Source)
 			pa.Close()
 
 		case req := <-pm.rpDescribe:

--- a/internal/readpublisher/readpublisher.go
+++ b/internal/readpublisher/readpublisher.go
@@ -75,6 +75,8 @@ type DescribeReq struct {
 	IP                  net.IP
 	ValidateCredentials func(authMethods []headers.AuthMethod, pathUser string, pathPass string) error
 	Res                 chan DescribeRes
+	RemoteAddr          string
+	LocalAddr           string
 }
 
 // SetupPlayRes is a setup/play response.
@@ -91,6 +93,8 @@ type SetupPlayReq struct {
 	IP                  net.IP
 	ValidateCredentials func(authMethods []headers.AuthMethod, pathUser string, pathPass string) error
 	Res                 chan SetupPlayRes
+	RemoteAddr          string
+	LocalAddr           string
 }
 
 // AnnounceRes is a announce response.

--- a/internal/rtmpconn/conn.go
+++ b/internal/rtmpconn/conn.go
@@ -217,7 +217,9 @@ func (c *Conn) runRead(ctx context.Context) error {
 		ValidateCredentials: func(authMethods []headers.AuthMethod, pathUser string, pathPass string) error {
 			return c.validateCredentials(pathUser, pathPass, query)
 		},
-		Res: sres,
+		Res:        sres,
+		RemoteAddr: c.conn.NetConn().RemoteAddr().String(),
+		LocalAddr:  c.conn.NetConn().LocalAddr().String(),
 	})
 	res := <-sres
 

--- a/internal/rtspconn/conn.go
+++ b/internal/rtspconn/conn.go
@@ -140,7 +140,9 @@ func (c *Conn) OnDescribe(ctx *gortsplib.ServerHandlerOnDescribeCtx) (*base.Resp
 		ValidateCredentials: func(authMethods []headers.AuthMethod, pathUser string, pathPass string) error {
 			return c.ValidateCredentials(authMethods, pathUser, pathPass, ctx.Path, ctx.Req)
 		},
-		Res: resc,
+		Res:        resc,
+		RemoteAddr: c.conn.NetConn().RemoteAddr().String(),
+		LocalAddr:  c.conn.NetConn().LocalAddr().String(),
 	})
 	res := <-resc
 

--- a/internal/rtspsession/session.go
+++ b/internal/rtspsession/session.go
@@ -196,7 +196,9 @@ func (s *Session) OnSetup(c *rtspconn.Conn, ctx *gortsplib.ServerHandlerOnSetupC
 			ValidateCredentials: func(authMethods []headers.AuthMethod, pathUser string, pathPass string) error {
 				return c.ValidateCredentials(authMethods, pathUser, pathPass, ctx.Path, ctx.Req)
 			},
-			Res: resc,
+			Res:        resc,
+			RemoteAddr: ctx.Conn.NetConn().RemoteAddr().String(),
+			LocalAddr:  ctx.Conn.NetConn().LocalAddr().String(),
 		})
 		res := <-resc
 

--- a/rtsp-simple-server.yml
+++ b/rtsp-simple-server.yml
@@ -220,3 +220,6 @@ paths:
     runOnRead:
     # the restart parameter allows to restart the command if it exits suddenly.
     runOnReadRestart: no
+
+    # Call this URL on Connects to validate or redirect the client
+    httpCallback:


### PR DESCRIPTION
On response, it handles the HTTP status as follows:

HTTP 200-299: Client is allowed to play the path, continue as normal and run through the entire rest of the setup procedure without any changes
HTTP 300-399: Client is allowed to play the path, but from a different configured source: than the one defined in the configuration. The HTTP backend should include a location HTTP header with the new proxy source, if that's not the case, close the rtsp client connection.
HTTP 400-499: Client is not allowed to play the path, reject playback.
Any other HTTP code or no HTTP response: Close the connection